### PR TITLE
Add (apparent) test coverage

### DIFF
--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -1,0 +1,26 @@
+package testutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bobg/lease"
+	"github.com/bobg/lease/mem"
+)
+
+// These tests already appear elsewhere in this library.
+// Duplicating them here solves a problem in how test coverage is measured.
+
+func factory(clock lease.Clock) (lease.Provider, error) {
+	p := mem.New()
+	p.Clock = clock
+	return p, nil
+}
+
+func TestLeader(t *testing.T) {
+	Leader(context.Background(), t, factory)
+}
+
+func TestProvider(t *testing.T) {
+	Provider(context.Background(), t, factory)
+}


### PR DESCRIPTION
This PR adds (duplicate) test coverage in `testutil`, in order to show a more accurate test-coverage total.

It also extends logic added in #1 to avoid relying on a Postgresql server's time when a Provider has a non-default clock.